### PR TITLE
fix: incorrect version of vnc in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@novnc/novnc": "^1.3.0",
+    "@novnc/novnc": "1.3.0",
     "vue": "^3.2.41"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix correct version of @novnc/novnc to 1.3.0 instead of ^1.3.0

Because it will cause error if latest novnc installed